### PR TITLE
support loading additional cache files from config.cache_d

### DIFF
--- a/script/constants.tlu
+++ b/script/constants.tlu
@@ -85,6 +85,7 @@ known_options = {
     'max_lines',
     'lang',
     'fuzzy_level',
+    'cache_d',
 }
 
 error_msg = [[

--- a/script/search.tlu
+++ b/script/search.tlu
@@ -454,6 +454,13 @@ function init_tlp_database()
         deb_print('tlpdb', 'Using shipped tlpdb data.')
         get_tlpinfo_from_dist()
     end
+    if ((config.cache_d ~= nil) and (config.cache_d ~= '') and lfs.isdir(config.cache_d)) then
+        for file in lfs.dir(config.cache_d) do
+            if string.match(string.lower(file), '%.([^/.]*)$') == 'lua' then
+                merge_into_cache(config.cache_d..'/'..file)
+            end
+        end
+    end
 end
 
 do -- begin scope of tlpinfo tables
@@ -568,6 +575,14 @@ end
 function get_tlpinfo_from_dist()
     local f = assert(kpse.find_file(C.data_tlpdb_name, 'texmfscripts'))
     s_meta, tlp_from_runfile, tlp_doclist = dofile(f)
+end
+
+-- merge pre-hashed data into current cache
+function merge_into_cache(filename)
+    local part_s_meta, part_tlp_from_runfile, part_tlp_doclist = dofile(filename)
+    for k,v in pairs(part_s_meta) do s_meta[k] = v end
+    for k,v in pairs(part_tlp_from_runfile) do tlp_from_runfile[k] = v end
+    for k,v in pairs(part_tlp_doclist) do tlp_doclist[k] = v end
 end
 
 -- get docfiles for pattern using specific tlpdb information


### PR DESCRIPTION
Hi Takuto,
in preparing for Debian inclusion and adaption of texdoc 3 and the new cache situation, I thought about supporting reading multiple or additional caches. The basic layout is:

New config variable
```
cache_d = /path/to/some/dir
```

Every file in this directory with extension `.lua` is read and should/need to return three tables. These three tables are merged into the respective cache tables.

As an example, I have set in my local texdoc.cnf the `cache_d` and put into that dir the following file:
```
local s_meta = { }
local tlp_from_runfile = {}
local tlp_doclist = {
  ["arstechnica"] = {
    "texmf/doc/guit/atguide.pdf",
  },
  ["pamath"] = {
    "texmf/doc/latex/pamath/pamathsm.pdf",
    "texmf/doc/latex/pamath/pamath.txt",
  },
}

return s_meta, tlp_from_runfile, tlp_doclist
```

After that I can run
```
$ texdoc -l pamath
 1 /usr/local/share/texmf/doc/latex/pamath/pamathsm.pdf
 2 /usr/local/share/texmf/doc/latex/pamath/pamath.txt
Enter number of file to view, RET to view 1, anything else to skip: 1
```

Open questions:

* should we support list of directories?
* should we support a fixed directory per texmf tree that is checked?
* need to check that the return value is a table (necessary? - not sure)

All the best