### PR TITLE
use overridable TEXMFROOT instead of unoverridable SELFAUTOPARENT

### DIFF
--- a/script/search.tlu
+++ b/script/search.tlu
@@ -403,7 +403,7 @@ end
 
 -- find the TeX Live root
 function get_tlroot()
-    local tlroot = kpse.var_value('SELFAUTOPARENT')
+    local tlroot = kpse.var_value('TEXMFROOT')
     get_tlroot = function() return tlroot end
     return tlroot
 end


### PR DESCRIPTION
The problem with using SELFAUTOPARENT in `get_tlroot` is that esp in distributions SELFAUTOPARENT will often point to something completely wrong (like `/`), while TEXMFROOT will point to to something more sensible.

Furthermore, TEXMFROOT is overridable with env variables, which SELFAUTOPARENT is not.

In total, I think using TEXMFROOT here is the better option.