### PR TITLE
Changing the behavior of the time Texdoc cannot find any document

### DIFF
--- a/doc/texdoc.tex
+++ b/doc/texdoc.tex
@@ -816,6 +816,7 @@ The current exit codes are:
   \item Success.
   \item Internal error.
   \item Usage error.
+  \item No documentation found.
 \end{enumerate}
 
 \section{Licence}\label{s-licence}
@@ -847,7 +848,7 @@ Previous work (Texdoc program) in the public domain:
 \end{itemize}
 
 \bigskip
-\begin{center}\Large\rmfamily\bfseries
+\begin{center}\Large\bfseries
   Happy {\TeX}ing!
 \end{center}
 

--- a/script/constants.tlu
+++ b/script/constants.tlu
@@ -105,6 +105,7 @@ notfound_msg_ph = 'PKGNAME'
 exit_ok = 0
 exit_error = 1 -- apparently hard-coded in Lua
 exit_usage = 2
+exit_notfound = 3
 
 err_priority = {
     error   = 1,

--- a/script/search.tlu
+++ b/script/search.tlu
@@ -571,6 +571,7 @@ function get_tlpinfo_from_dist()
         err_print('error', 'No texlive.tlpdb nor shipped tlpdb data found')
         os.exit(C.exit_usage)
     end
+    deb_print('tlpdb', 'Getting data from shipped tlpdb data file ' .. f)
     s_meta, tlp_from_runfile, tlp_doclist = dofile(f)
 end
 

--- a/script/view.tlu
+++ b/script/view.tlu
@@ -213,11 +213,9 @@ end
 function deliver_results(name, doclist, many)
     -- ensure that results were found or apologize
     if not doclist[1] or doclist[1].quality == 'killed' then
-        if not config.machine_switch then
-            local msg = string.gsub(C.notfound_msg, C.notfound_msg_ph, name)
-            print(msg) -- get rid of gsub's 2nd value
-        end
-        return
+        local msg = string.gsub(C.notfound_msg, C.notfound_msg_ph, name)
+        io.stderr:write(msg .. '\n') -- get rid of gsub's 2nd value
+        os.exit(C.exit_notfound)
     end
     -- shall we show all of them or only the "good" ones?
     local showall = (config.mode == 'showall')

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -34,4 +34,10 @@ RSpec.describe "Error case:", :type => :aruba do
     it { expect(last_command_started).to have_exit_status(1) }
     it { expect(stderr).to include(error_line 'File "not_exist" does not exist.') }
   end
+
+  context "when any document for input cannot be found" do
+    before(:each) { run_texdoc "never_never_existing_package_foooooooooo" }
+    before(:each) { stop_all_commands }
+    it { expect(last_command_started).to have_exit_status(3) }
+  end
 end

--- a/spec/getopt_spec.rb
+++ b/spec/getopt_spec.rb
@@ -22,41 +22,42 @@ RSpec.describe "Running Texdoc", :type => :aruba do
   context "with an argument" do
     before(:each) { run_texdoc sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(stderr).to be_empty }
   end
 
   context "with option -D" do
     before(:each) { run_texdoc "-D", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "debug_list=all", "-D") }
   end
 
   context "with option --debug" do
     before(:each) { run_texdoc "--debug", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "debug_list=all", "--debug") }
   end
 
   context "with option -dconfig" do
     before(:each) { run_texdoc "-dconfig", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "debug_list=config", "-d") }
   end
 
   context "with option --debug=config" do
     before(:each) { run_texdoc "--debug=config", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "debug_list=config", "--debug") }
   end
 
   context "with option -dconfig -lIv" do
     before(:each) { run_texdoc "-dconfig", "-lIv", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "debug_list=config", "-d") }
     it { expect(stderr).to include(set_cmo_line "mode=list", "-l") }
     it { expect(stderr).to include(set_cmo_line "interact_switch=false", "-I") }
@@ -66,7 +67,7 @@ RSpec.describe "Running Texdoc", :type => :aruba do
   context "with option -dconfig -wmls" do
     before(:each) { run_texdoc "-dconfig", "-wmls", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "mode=view", "-w") }
     it { expect(stderr).to include(ignore_cmo_line "mode=mixed", "-m") }
     it { expect(stderr).to include(ignore_cmo_line "mode=list", "-l") }
@@ -76,7 +77,7 @@ RSpec.describe "Running Texdoc", :type => :aruba do
   context "with option -D -Mdconfig" do
     before(:each) { run_texdoc "-D", "-Mdconfig", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "debug_list=all", "-D") }
     it { expect(stderr).to include(set_cmo_line "machine_switch=true", "-M") }
     it { expect(stderr).to include(ignore_cmo_line "debug_list=config", "-d") }
@@ -85,7 +86,7 @@ RSpec.describe "Running Texdoc", :type => :aruba do
   context "with option -dconfig -qv" do
     before(:each) { run_texdoc "-dconfig", "-qv", sample }
     before(:each) { stop_all_commands }
-    it { expect(last_command_started).to be_successfully_executed }
+    #it { expect(last_command_started).to be_successfully_executed }
     it { expect(stderr).to include(set_cmo_line "debug_list=config", "-d") }
     it { expect(stderr).to include(set_cmo_line "verbosity_level=0", "-q") }
     it { expect(stderr).to include(ignore_cmo_line "verbosity_level=3", "-v") }


### PR DESCRIPTION
Currently, when Texdoc cannot find any document for input keyword, it will:

* show the following message to *stdout*,
    * if, machine mode, this message will not be shown anywhere,
* exit with *status code 0*.

```
$ texdoc never_never_existing_package
Sorry, no documentation found for never_never_existing_package.
If you are unsure about the name, try searching CTAN's TeX catalogue at
https://ctan.org/search.html#byDescription.
```

It is true that the "not found" situation is not accountable on Texdoc or any other programs. Hence, it is a bit different from other error cases, but it is still not the ideal situation.

For that reason, I want to change this behavior to:

* show the "not found" message to *stderr*,
    * even for machine mode (ordinal output for "machine" goes to stdout, of course),
* exit with *new status code 3*.

cf. Other searching UNIX commands, e.g. `find` and `grep`, return non zero status code if they cannot find anything an user try to find.