### PR TITLE
sort some tables by keys (fix #24)

### DIFF
--- a/script/config.tlu
+++ b/script/config.tlu
@@ -121,8 +121,11 @@ end
 
 -- set a whole list, also whithout overwriting
 function set_config_list(conf, context)
-    for key, value in pairs(conf) do
-        set_config_element(key, value, context)
+    local tkeys = {}
+    for k in pairs(conf) do table.insert(tkeys, k) end
+    table.sort(tkeys)
+    for _, key in ipairs(tkeys) do
+        set_config_element(key, conf[key], context)
     end
 end
 

--- a/script/score.tlu
+++ b/script/score.tlu
@@ -106,7 +106,11 @@ function set_score(df, original_kw)
     end
     -- adjust from global tables
     if df.tree > -1 then
-        for pat, val in pairs(global_adjscore) do
+        local tkeys = {}
+        for k in pairs(global_adjscore) do table.insert(tkeys, k) end
+        table.sort(tkeys)
+        for _, pat in ipairs(tkeys) do
+            val = global_adjscore[pat]
             if val and is_subword('/' .. name, pat) then
                 if score > -10 or val < 0 then score = score + val end
                 dbg_print('score', string.format(

--- a/script/search.tlu
+++ b/script/search.tlu
@@ -324,8 +324,11 @@ end
 
 -- scan a database
 function scan_db(patlist, code, lsr_db)
-    for file, basename in pairs(lsr_db) do
-        local df = process_file(patlist, basename, file, code)
+    local tkeys = {}
+    for k in pairs(lsr_db) do table.insert(tkeys, k) end
+    table.sort(tkeys)
+    for _, file in ipairs(tkeys) do
+        local df = process_file(patlist, lsr_db[file], file, code)
         if df then s_doclist:add(df) end
     end
 end


### PR DESCRIPTION
This PR *probably* fix #24 — some tables in `script/score.tlu` are not sorted by assuming few candidates, e.g., alias  (or should I?)

Debug outputs are always same for beamer, tikz, texdoc etc over dozen times.

ref: https://stackoverflow.com/questions/26160327/sorting-a-lua-table-by-key#26166560