### PR TITLE
fix script/score.tlu: compare realpath instead of basename

### DIFF
--- a/script/score.tlu
+++ b/script/score.tlu
@@ -224,7 +224,7 @@ end
 -- compare two docfile's: (see search.tlu for structure)
 -- 1. by score
 -- 2. then by extensions (ordered as in ext_list),
--- 3. then lexicographically by filename.
+-- 3. then lexicographically by fullpath.
 -- 4. then by tree.
 -- return true if a is better than b
 function docfile_order (a, b)
@@ -232,8 +232,8 @@ function docfile_order (a, b)
     elseif a.score < b.score       then return false
     elseif a.ext_pos < b.ext_pos   then return true
     elseif a.ext_pos > b.ext_pos   then return false
-    elseif a.basename < b.basename then return true
-    elseif a.basename > b.basename then return false
+    elseif a.realpath < b.realpath then return true
+    elseif a.realpath > b.realpath then return false
     else return (a.tree > b.tree)
     end
 end


### PR DESCRIPTION
For example `texdoc -Il thesis` returns lists in arbitrary orders:
```shellsession
$  diff -U1 <(texdoc -Il thesis) <(texdoc -Il thesis)
--- /proc/self/fd/11	2018-08-03 14:20:14.060909785 +0900
+++ /proc/self/fd/12	2018-08-03 14:20:14.060909785 +0900
@@ -33,17 +33,17 @@
    = [de] Example document / Tutorial (German)
-18 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbArticle/main.pdf
+18 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/Manual/main.pdf
    = [de] Example document / Tutorial (German)
-19 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbLabReportDE/main.pdf
+19 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbInternshipReport/main.pdf
    = [de] Example document / Tutorial (German)
-20 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbThesisTutorial/main.pdf
+20 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbLabReportDE/main.pdf
    = [de] Example document / Tutorial (German)
-21 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbInternshipReport/main.pdf
+21 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbThesisEN/main.pdf
    = [de] Example document / Tutorial (German)
-22 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbTermReport/main.pdf
+22 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbThesisTutorial/main.pdf
    = [de] Example document / Tutorial (German)
-23 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/Manual/main.pdf
+23 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbArticle/main.pdf
    = [de] Example document / Tutorial (German)
-24 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbThesisEN/main.pdf
+24 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbLabReportEN/main.pdf
    = [de] Example document / Tutorial (German)
-25 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbLabReportEN/main.pdf
+25 /usr/local/texlive/2018/texmf-dist/doc/latex/hagenberg-thesis/examples/HgbTermReport/main.pdf
    = [de] Example document / Tutorial (German)
# ommitted
```

There are many packages whose names contain "thesis", and some files of them have the same score (e.g., 1.5 to `hagenberg-thesis/examples/hgblabreportde/main.pdf`, `hagenberg-thesis/examples/hgblabreporten/main.pdf` and other 8).
The problem is that `sort_doclist` compares *basenames* when scores are same, leading to arbitrary order of files whose basenames are same.