### PR TITLE
Document Irreproducibility of Fuzzy Search and Some Related Improvements

### DIFF
--- a/doc/texdoc.tex
+++ b/doc/texdoc.tex
@@ -438,6 +438,9 @@ The default allowance of Levenshtein distance is 5. You can change this
 default value by specifying |fuzzy_level| in your |texdoc.cnf| (see
 \ref{cf-fuzzy_level}).
 
+Note that a result of fuzzy search is irreproducible if multiple strings have
+the same Levenshtein distance.
+
 \clearpage
 
 \section{Full reference}

--- a/script/config.tlu
+++ b/script/config.tlu
@@ -26,6 +26,7 @@ real_set_config = set_read_only(config, 'config')
 -- set a config parameter, but don't overwrite it if already set
 -- three special types: *_list (list), *_switch (boolean), *_level (number)
 function set_config_element(key, value, context)
+    local parse_error = false
     local is_known = false -- is key a valid option?
     local option
     for _, option in ipairs(C.known_options) do
@@ -71,6 +72,7 @@ function set_config_element(key, value, context)
             real_set_config(key, false)
         else
             config_warn(key, value, context)
+            parse_error = true
         end
     elseif string.find(key, '_level$') then
         -- integer
@@ -79,6 +81,7 @@ function set_config_element(key, value, context)
             real_set_config(key, val)
         else
             config_warn(key, value, context)
+            parse_error = true
         end
     else -- string
         real_set_config(key, value)
@@ -88,9 +91,11 @@ function set_config_element(key, value, context)
         dbg_print('version', C.fullname .. ' version ' .. C.version)
     end
     -- now tell what we have just done, for debugging
-    dbg_print('config',
-        'Setting "' .. key .. '=' .. value .. '" ' ..
-        context_to_string(context) .. '.')
+    if not parse_error then
+        dbg_print('config',
+            'Setting "' .. key .. '=' .. value .. '" ' ..
+            context_to_string(context) .. '.')
+    end
 end
 
 -- a helper function for warning messages in the above

--- a/script/search.tlu
+++ b/script/search.tlu
@@ -614,8 +614,8 @@ end
 -- fuzzy search by using Levenshtein distance
 function fuzzy_search(pattern)
     local tmp_d
-    local min = 100
-    local result
+    local min = math.huge
+    local result = ''
 
     for p in pairs(tlp_doclist) do
         tmp_d = levenshtein(pattern, p)
@@ -624,11 +624,7 @@ function fuzzy_search(pattern)
         end
     end
 
-    if min <= config.fuzzy_level then
-        return result
-    else
-        return ''
-    end
+    return result, min
 end
 
 -- calculate Levenshtein distance by dynamic programming
@@ -666,12 +662,16 @@ function get_doclist(pattern, no_alias)
     -- 1. normal search with the input pattern
     doc_search(pattern, no_alias)
     -- 2. if no result, execute fuzzy search
-    if not s_doclist[1] then
-        local f_res = fuzzy_search(pattern)
-        if f_res ~= '' then
+    if not s_doclist[1] and config.fuzzy_level > 0 then
+        local f_res, f_lev = fuzzy_search(pattern)
+        if f_lev <= config.fuzzy_level then
             err_print('info', 'Fuzzy search result: ' .. f_res)
+            dbg_print('search', 'Levenshtein distance: ' .. f_lev)
             pattern = f_res
             doc_search(pattern, no_alias)
+        else
+            dbg_print('search', 'Fuzzy search result: ' .. f_res)
+            dbg_print('search', 'Levenshtein distance: ' .. f_lev)
         end
     end
     -- finally, sort results


### PR DESCRIPTION
- document irreproducibility of fuzzy search
- do not perform fuzzy search if `fuzzy_level` <= 0
- now `fuzzy_search` returns calculated Levenshtein distance
- improve debug output:
   - do not print `Setting "key=value" from command line option "-c".` if parse failed
  - print whether fuzzy search is performed or not
  - print Levenshtein distance of the result