### PR TITLE
Support GIO on GNOME

### DIFF
--- a/script/texdoclib-config.tlu
+++ b/script/texdoclib-config.tlu
@@ -393,6 +393,7 @@ local function desktop_environment_viewer()
     end
     if os.getenv('GNOME_DESKTOP_SESSION_ID')
         or string.match(xdg_current_desktop, '.*GNOME.*') then  -- gnome
+        if is_in_path('gio') then return '(gio open %s) &' end
         if is_in_path('gvfs-open') then return '(gvfs-open %s) &' end
         if is_in_path('gnome-open') then return '(gnome-open %s) &' end
     end


### PR DESCRIPTION
`gvfs-open` was deprecated and replaced with `gio open`
https://gitlab.gnome.org/GNOME/gvfs/commit/2f28fa49cfeb1c82927a1c7c0021b15e2742149f