### PR TITLE
Send users online when they have no local docs.

### DIFF
--- a/doc/texdoc-doc.cls
+++ b/doc/texdoc-doc.cls
@@ -219,6 +219,12 @@
     \hypertarget{\@tmp@hyname}{\code{#1 = #2}}%
     \IfNoValueF{#3}{\hfill (#3)}%
     \begin{manual@entry}%
+    \bgroup%
+      \def\meta##1{##1}%
+      \def\_{\string_}%
+      \edef\conf@title{#1}%
+      \belowpdfbookmark{\conf@title}{\conf@title}%
+    \egroup%
   }
   {\ifvmode\else\unskip\fi\end{manual@entry}}
 

--- a/doc/texdoc.tex
+++ b/doc/texdoc.tex
@@ -504,6 +504,25 @@ allowance by using the configuration item \ci{fuzzy\_level}. Results of fuzzy
 search could be different among executions if multiple package names have the
 same Levenshtein distance to the input.
 
+\subsection{Online Search}
+\label{sec:online}
+
+If Texdoc cannot find any good matches for a document, it may sometimes prompt
+you to search online.
+
+If you use the |view| option, there are no ``good'' matches
+(|score|${}\ge{}$0), but you have some local documentation installed, Texdoc will show you the three best locally-installed documents while also prompting
+you to search online.
+
+If you use the |view| option when you have no local documentation installed,
+Texdoc will skip showing any fuzzy matches, and will instead prompt you to
+search online immediately.
+
+Texdoc checks to see if the |kpathsea| documentation as a heuristic for
+if \emph{any} documentation is installed. If the documentation for Texdoc is
+installed, but no other documentation is installed, the online search prompt
+may produce unexpected results.
+
 \section{Configuration items}
 \label{sec:conf}
 
@@ -725,6 +744,11 @@ Texdoc uses for searching documents. By default, Texdoc uses
 not) set this configuration item. This is only useful when you want to use
 Texdoc within a {\TL}-based {\TeX} distribution which does not ship
 |texlive.tlpdb|.
+\end{confitem}
+
+\begin{confitem}{online\_url}{\meta{url}}[default: \code{https://texdoc.org/serve/PKG/0}]
+Sets the URL to use for online documentation. Texdoc will replace |PKG| with
+the name of the package to search for.
 \end{confitem}
 
 \section{Licence}

--- a/script/texdoclib-config.tlu
+++ b/script/texdoclib-config.tlu
@@ -545,6 +545,7 @@ local function setup_config_from_defaults()
         debug_list = '',
         max_lines = '20',
         fuzzy_level = '3',
+        online_url = 'https://texdoc.org/serve/PKG/0',
     }
     -- zip-related options
     set_config_ls {

--- a/script/texdoclib-const.tlu
+++ b/script/texdoclib-const.tlu
@@ -102,6 +102,35 @@ If you are unsure about the name, try full-text searching on CTAN.
 Search form: <https://www.ctan.org/search/>]]
 notfound_msg_ph = 'PKGNAME'
 
+badmatch_msg = [[
+Unfortunately, I couldn't find any good matches for "PKG".
+
+Here are the top 3 matches that I found:
+]]
+badmatch_msg_ph = 'PKG'
+badmatch_prompt = [[
+Enter (1/2/3) to open one of the listed documents, (y) to search online, or any other key to exit:
+]]
+
+nolocaldocs_msg = [[
+You don't appear to have any local documentation installed.
+
+]]
+nolocaldocs_prompt = [[
+Would you like to search online? (y/N)
+]]
+
+online_msg = [[
+There may be online documentation available for "PKG" at
+    URL
+This documentation may be for a different version than you have installed.
+
+]]
+online_msg_url = 'URL'
+online_msg_ph = 'PKG'
+online_baseurl = 'https://texdoc.org/serve/PKG/0'
+online_baseurl_ph = 'PKG'
+
 -- exit codes
 exit_ok = 0
 exit_error = 1  -- apparently hard-coded in Lua

--- a/script/texdoclib-const.tlu
+++ b/script/texdoclib-const.tlu
@@ -91,6 +91,7 @@ known_options = {
     'lang',
     'fuzzy_level',
     'texlive_tlpdb',
+    'online_url',
 }
 
 error_msg = [[
@@ -112,6 +113,12 @@ badmatch_prompt = [[
 Enter (1/2/3) to open one of the listed documents, (y) to search online, or any other key to exit:
 ]]
 
+nomatch_msg = [[
+Unfortunately, I couldn't find any matches for "PKG".
+
+]]
+nomatch_msg_ph = 'PKG'
+
 nolocaldocs_msg = [[
 You don't appear to have any local documentation installed.
 
@@ -128,7 +135,6 @@ This documentation may be for a different version than you have installed.
 ]]
 online_msg_url = 'URL'
 online_msg_ph = 'PKG'
-online_baseurl = 'https://texdoc.org/serve/PKG/0'
 online_baseurl_ph = 'PKG'
 
 -- exit codes

--- a/script/texdoclib-view.tlu
+++ b/script/texdoclib-view.tlu
@@ -169,8 +169,8 @@ local function print_menu(name, doclist, showall)
         -- there may be too many lines, count them
         local n = 0
         for _, doc in pairs(doclist) do
-            if doc.quality == 'good' or
-                    (showall and doc.quality ~= 'killed') then
+            if doc:get_quality() == 'good' or
+                    (showall and doc:get_quality() ~= 'killed') then
                 n = n + 1
             end
         end
@@ -187,8 +187,8 @@ local function print_menu(name, doclist, showall)
     end
     local i, doc, last_i
     for i, doc in ipairs(doclist) do
-        if doc.quality == 'killed' then break end
-        if doc.quality ~= 'good' and not showall then break end
+        if doc:get_quality() == 'killed' then break end
+        if doc:get_quality() ~= 'good' and not showall then break end
         if texdoc.config.get_value('machine_switch') == true then
             print(name, doc.score, texdoc.util.w32_path(doc.realpath),
             doc.lang or '', doc.details or '')

--- a/script/texdoclib-view.tlu
+++ b/script/texdoclib-view.tlu
@@ -7,6 +7,7 @@ local texdoc = {
     const = require('texdoclib-const'),
     util = require('texdoclib-util'),
     config = require('texdoclib-config'),
+    search = require('texdoclib-search'),
 }
 
 -- shortcuts
@@ -116,6 +117,10 @@ function M.view_file(filename)
     -- files without extension are assumed to be text
     local viewext = (filename:match('.*%.([^/]*)$') or 'txt'):lower()
 
+    if filename:match('^http') then
+        viewext = 'html'
+    end
+
     -- special case : sty files use txt viewer
     -- FIXME: hardcoding such cases this way is not very clean
     if viewext == 'sty' then viewext = 'txt' end
@@ -211,31 +216,80 @@ local function print_menu(name, doclist, showall)
     end
 end
 
+local function search_online(name, doclist)
+    if not texdoc.config.get_value('interact_switch') or
+        texdoc.config.get_value('machine_switch')
+    then
+        view_doc(doclist[1])
+        return
+    end
+
+    local function write(msg)
+        io.stderr:write(msg .. '') -- cast to string
+    end
+    -- Fuzzy heuristic to see if the user has _any_ local documentation
+    local texdoc_docs = texdoc.search.get_doclist("texdoc")
+    local docs_installed = texdoc[1] and texdoc[1].basename == "texdoc.pdf"
+
+    if docs_installed then
+        write(C.badmatch_msg:gsub(C.badmatch_msg_ph, name))
+
+        for i=1,3 do
+            local doc = (doclist[i] and doclist[i].normname) or '<empty>'
+            write('    ' .. i .. ' ' .. doc .. '\n')
+        end
+        write('\n')
+    else
+        write(C.nolocaldocs_msg)
+    end
+
+    local url = C.online_baseurl:gsub(C.online_baseurl_ph, name)
+    write(C.online_msg:gsub(C.online_msg_url, url)
+                      :gsub(C.online_msg_ph, name))
+
+    if docs_installed then
+        write(C.badmatch_prompt)
+    else
+        write(C.nolocaldocs_prompt)
+    end
+
+    local ans = io.read('*line')
+
+    if ans:match('^\r?[yY]') then
+        M.view_file(url)
+    elseif tonumber(ans) then
+        view_doc(doclist[tonumber(ans)])
+    end
+end
+
 -----------------------   deliver results based on mode   ---------------------
 
 function M.deliver_results(name, doclist, many)
     -- ensure that results were found or apologize
-    if not doclist[1] or doclist[1].quality == 'killed' then
+    if (not doclist[1] or doclist[1]:get_quality() == 'killed') and
+        not texdoc.config.get_value('interact_switch')
+    then
         local msg = string.gsub(C.notfound_msg, C.notfound_msg_ph, name)
         io.stderr:write(msg .. '\n') -- get rid of gsub's 2nd value
         os.exit(C.exit_notfound)
     end
     -- shall we show all of them or only the "good" ones?
-    local showall = (texdoc.config.get_value('mode') == 'showall')
-    if not showall and doclist[1].quality ~= 'good' then
-        showall = true
-        err_print('info', 'No good result found, showing all results.')
-    end
+    local mode = texdoc.config.get_value('mode')
+
     -- view result or show menu based on mode and number of results
-    if (texdoc.config.get_value('mode') == 'view')
-            or texdoc.config.get_value('mode') == 'mixed' and (not doclist[2]
-            or (doclist[2].quality ~= 'good' and not showall)) then
+    if (mode == 'view' and doclist[1] and doclist[1]:get_quality() == 'good') or
+        (mode == 'mixed' and
+            (not doclist[2] or doclist[2]:get_quality() ~= 'good')
+        )
+    then
         view_doc(doclist[1])
-    else
+    elseif mode ~= 'view' then
         if many and not texdoc.config.get_value('machine_switch') then
             print('*** Results for: ' .. name .. ' ***')
         end
-        print_menu(name, doclist, showall)
+        print_menu(name, doclist, mode == 'showall')
+    else
+        search_online(name, doclist)
     end
 end
 

--- a/script/texdoclib-view.tlu
+++ b/script/texdoclib-view.tlu
@@ -228,10 +228,12 @@ local function search_online(name, doclist)
         io.stderr:write(msg .. '') -- cast to string
     end
     -- Fuzzy heuristic to see if the user has _any_ local documentation
-    local texdoc_docs = texdoc.search.get_doclist("texdoc")
-    local docs_installed = texdoc[1] and texdoc[1].basename == "texdoc.pdf"
+    local kpathsea_docs = texdoc.search.get_doclist("kpathsea")
+    local docs_installed = kpathsea_docs[1] and
+                           kpathsea_docs[1].basename == "kpathsea.pdf" and
+                           not os.getenv("TEXDOC_NO_LOCAL_DOCS")
 
-    if docs_installed then
+    if docs_installed and doclist[1] then
         write(C.badmatch_msg:gsub(C.badmatch_msg_ph, name))
 
         for i=1,3 do
@@ -239,15 +241,19 @@ local function search_online(name, doclist)
             write('    ' .. i .. ' ' .. doc .. '\n')
         end
         write('\n')
+    elseif docs_installed then
+        write(C.nomatch_msg:gsub(C.nomatch_msg_ph, name))
     else
         write(C.nolocaldocs_msg)
     end
 
-    local url = C.online_baseurl:gsub(C.online_baseurl_ph, name)
+    local url = texdoc.config.get_value('online_url')
+                :gsub(C.online_baseurl_ph, name)
+
     write(C.online_msg:gsub(C.online_msg_url, url)
                       :gsub(C.online_msg_ph, name))
 
-    if docs_installed then
+    if docs_installed and doclist[1] then
         write(C.badmatch_prompt)
     else
         write(C.nolocaldocs_prompt)

--- a/spec/misc/errors_spec.rb
+++ b/spec/misc/errors_spec.rb
@@ -53,14 +53,7 @@ RSpec.describe "Errors", :type => :aruba do
     before(:each) { run_texdoc nonexist_pkg }
 
     it 'result in the "not found" error' do
-      expect(stderr).to include(
-        <<~EXPECTED
-          Sorry, no documentation found for "#{nonexist_pkg}".
-          If you are unsure about the name, try full-text searching on CTAN.
-          Search form: <https://www.ctan.org/search/>
-        EXPECTED
-      )
-      expect(last_command_started).to have_exit_status(3)
+      expect(stderr).to include("Unfortunately, I couldn't find any matches for")
     end
   end
 end

--- a/spec/misc/verbose_spec.rb
+++ b/spec/misc/verbose_spec.rb
@@ -14,13 +14,4 @@ RSpec.describe "Verbose outputs", :type => :aruba do
       expect(last_command_started).to be_successfully_executed
     end
   end
-
-  context "if no good result found" do
-    before(:each) { run_texdoc "-lIv", "-c ext_list=md", "times" }
-
-    it "should show an info message" do
-      expect(stderr).to include(
-        info_line "No good result found, showing all results.")
-    end
-  end
 end

--- a/spec/search/online_spec.rb
+++ b/spec/search/online_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'pathname'
+
+RSpec.describe "Online searches", :type => :aruba do
+  include_context "messages"
+
+  context "with no local docs" do
+    before(:each) { set_environment_variable "TEXDOC_NO_LOCAL_DOCS", "true" }
+    before(:each) {
+        run_texdoc \
+        "-dtlpdb",
+        "-i",
+        "-c texlive_tlpdb=" + Pathname.pwd.to_s + "/spec/support/no-docs.tlpdb",
+        "lua-widow-control"
+    }
+
+    it 'should say no docs installed' do
+      expect(stderr).to include(
+        "You don't appear to have any local documentation installed."
+    )
+    end
+  end
+
+  context "bad fuzzy results" do
+    before(:each) {
+        run_texdoc "-i", "scrgui"
+    }
+
+    it 'should say no good matches' do
+      expect(stderr).to include(
+        "Unfortunately, I couldn't find any good matches"
+    )
+    end
+  end
+end

--- a/spec/support/no-docs.tlpdb
+++ b/spec/support/no-docs.tlpdb
@@ -1,0 +1,106 @@
+name 00texlive.config
+category Package
+depend minrelease/2016
+depend release/2022
+
+name 00texlive.installation
+category TLCore
+depend opt_install_docfiles:0
+depend opt_install_srcfiles:0
+
+name lua-widow-control
+category Package
+revision 63994
+shortdesc Automatically remove widows and orphans from any document
+longdesc Unmodified TeX has very few ways of preventing widows and
+longdesc orphans. In documents with figures, section headings, and
+longdesc equations, TeX can stretch the vertical glue between items in
+longdesc order to prevent widows and orphans, but many documents have no
+longdesc figures or headings. TeX can also shorten the page by 1 line,
+longdesc but this will give each page a different length which can make
+longdesc a document look uneven. The typical solution is to
+longdesc strategically insert \looseness=1, but this requires manual
+longdesc editing every time that the document is edited.
+longdesc Lua-widow-control is essentially an automation of the
+longdesc \looseness method: it uses Lua callbacks to find "stretchy"
+longdesc paragraphs, then it lengthens them to remove widows and
+longdesc orphans. Lua-widow-control is compatible with all LuaTeX-based
+longdesc formats. All that is required is to load the package at the
+longdesc start of your document. To load: Plain LuaTeX: \input
+longdesc lua-widow-control LuaLaTeX: \usepackage{lua-widow-control}
+longdesc ConTeXt: \usemodule[lua-widow-control] OpTeX:
+longdesc \load[lua-widow-control]
+containersize 16396
+containerchecksum c8d4cdd72687ff990ce2f591ec0f7081b5a7fa822e4bb4d5cd00f32ce34b9177b18e582e0d6b9dda5a99568226915abd6b367b8808630787fba71590ad54d63f
+doccontainersize 745928
+doccontainerchecksum 6dc59ea9bffa68f543af29adc1eec155aebe96b7f802a7796d0fbef3a7b4765e74f570cf901c3398afad1437c610a4bdbd56af5b8a6d9ddf11334e16b5875240
+srccontainersize 47940
+srccontainerchecksum afe2c83278b7dc5b73e4e52adb04384f1df2497c53c89f3112c1da4b4399d5e21f97b10c8a57e0646a639f3f42201c9596c669f4a0a7650736c25c240c5f0864
+runfiles size=19
+ texmf-dist/tex/context/third/lua-widow-control/t-lua-widow-control.mkiv
+ texmf-dist/tex/context/third/lua-widow-control/t-lua-widow-control.mkxl
+ texmf-dist/tex/lualatex/lua-widow-control/lua-widow-control-2022-02-22.sty
+ texmf-dist/tex/lualatex/lua-widow-control/lua-widow-control.sty
+ texmf-dist/tex/luatex/lua-widow-control/lua-widow-control.lua
+ texmf-dist/tex/luatex/lua-widow-control/lua-widow-control.tex
+ texmf-dist/tex/optex/lua-widow-control/lua-widow-control.opm
+catalogue-contact-bugs https://github.com/gucci-on-fleek/lua-widow-control/issues
+catalogue-contact-repository https://github.com/gucci-on-fleek/lua-widow-control
+catalogue-contact-support https://github.com/gucci-on-fleek/lua-widow-control/discussions
+catalogue-ctan /macros/luatex/generic/lua-widow-control
+catalogue-license other-free cc-by-sa-4
+catalogue-topics layout luatex expl3
+catalogue-version 2.2.1
+
+name kpathsea
+category TLCore
+revision 63534
+shortdesc Path searching library for TeX-related files
+longdesc Kpathsea is a library and utility programs which provide path
+longdesc searching facilities for TeX file types, including the
+longdesc self-locating feature required for movable installations,
+longdesc layered on top of a general search mechanism. It is not
+longdesc distributed separately, but rather is released and maintained
+longdesc as part of the TeX Live sources.
+depend kpathsea.ARCH
+containersize 32472
+containerchecksum fc14de3c5a2d42b27c1bc3eddfcb1da4c615b9ef84df2687388ca637244ec2a32ec332b6de7db8d7e61e5535d217e42a3f869cd8df32fbc85662a990461f41ca
+doccontainersize 1079700
+doccontainerchecksum 1ebd180d7047b7393fdfd862f0509e9d0dc7c0aa7306457675e08f151b785440caba794146b357c76f1588cd1979526b40d841807218b92f9992208b1b47f1ab
+runfiles size=52
+ texmf-dist/web2c/amiga-pl.tcx
+ texmf-dist/web2c/cp1250cs.tcx
+ texmf-dist/web2c/cp1250pl.tcx
+ texmf-dist/web2c/cp1250t1.tcx
+ texmf-dist/web2c/cp227.tcx
+ texmf-dist/web2c/cp852-cs.tcx
+ texmf-dist/web2c/cp852-pl.tcx
+ texmf-dist/web2c/cp8bit.tcx
+ texmf-dist/web2c/empty.tcx
+ texmf-dist/web2c/fmtutil.cnf
+ texmf-dist/web2c/il1-t1.tcx
+ texmf-dist/web2c/il2-cs.tcx
+ texmf-dist/web2c/il2-pl.tcx
+ texmf-dist/web2c/il2-t1.tcx
+ texmf-dist/web2c/kam-cs.tcx
+ texmf-dist/web2c/kam-t1.tcx
+ texmf-dist/web2c/macce-pl.tcx
+ texmf-dist/web2c/macce-t1.tcx
+ texmf-dist/web2c/maz-pl.tcx
+ texmf-dist/web2c/mktex.cnf
+ texmf-dist/web2c/mktex.opt
+ texmf-dist/web2c/mktexdir
+ texmf-dist/web2c/mktexdir.opt
+ texmf-dist/web2c/mktexnam
+ texmf-dist/web2c/mktexnam.opt
+ texmf-dist/web2c/mktexupd
+ texmf-dist/web2c/natural.tcx
+ texmf-dist/web2c/tcvn-t5.tcx
+ texmf-dist/web2c/texmf.cnf
+ texmf-dist/web2c/viscii-t5.tcx
+catalogue-contact-bugs https://lists.tug.org/tex-k
+catalogue-contact-home https://tug.org/kpathsea
+catalogue-contact-repository https://tug.org/svn/texlive/trunk/Build/source/texk/kpathsea/
+catalogue-contact-support https://lists.tug.org/tex-k
+catalogue-license lgpl2.1
+catalogue-topics sys-supp

--- a/texdoc.cnf
+++ b/texdoc.cnf
@@ -93,6 +93,13 @@ suffix_list = doc, -doc, _doc, .doc, /doc, manual, /manual, -manual, userguide, 
 #
 # fuzzy_level = 3
 
+## Online URL
+
+# Here you can configure the URL to prompt the user to open when Texdoc
+# is unable to find any local matches.
+
+# online_url = https://texdoc.org/serve/PKG/0
+
 # Score adjustments
 # =================
 


### PR DESCRIPTION
Many users choose to install TeX Live without any documentation. This means that `texdoc` is completely unhelpful, since it only searches locally. This commit makes it so that `texdoc` detects if *any* local documentation exists; if it does, it searches as normal; if not, it informs the user and offers to open online documentation for them.

This is mentioned in the wiki TODO as a desirable feature:

> ## Getting documents from CTAN mirrors
> 
> Some TeX Live users install TeX Live without documentation. For those users, current Texdoc is useless at all.
> 
> Then, how about implementing a feature to download a document on demand if the document does not exist in the local TEXMFs? I first thought that this is meaningless because it requires the Internet connection; thus, it is far better for the users who can always use (good) newtworks to search with Google (or whatever). But if we cache the document once downloaded, doesn't it make the feature useful?
> 
> The problem here is that the versions of the documents and those of the actual packages installed in the local TEXMFs could be different. Can we ignore that difference?

My current implementation is pretty crude, so I'll likely need to make some changes before you can merge this. Please let me know if you have any suggestions or feedback.