### PR TITLE
Re-enable alias for `xetex`

### DIFF
--- a/texdoc.cnf
+++ b/texdoc.cnf
@@ -297,7 +297,7 @@ alias xelatex = xetex-reference
 alias e-tex = etex_man
 alias etex = etex_man
 alias pdftex = pdftex-a
-#alias xetex = xetex-reference # OK
+alias xetex = xetex-reference # needed by packages with "xetex" in their names
 alias xelatex = xetex-reference
 
 alias e-tex-man = etex.man1


### PR DESCRIPTION
Since @AlphaZTX contributed package [`unimath-plain-xetex`](https://ctan.org/pkg/unimath-plain-xetex) to CTAN and then TeX Live contained it, `texdoc xetex` now opens `unimath-plain-xetex.pdf` instead of `xetex-reference.pdf`.
```bash
$ texdoc -lM xetex | head -5
xetex	6.5	/usr/local/texlive/2022basic/texmf-dist/doc/xetex/unimath-plain-xetex/unimath-plain-xetex-doc.pdf		Package documentation
xetex	6.5	/usr/local/texlive/2022basic/texmf-dist/doc/xetex/xetexref/xetex-reference.pdf		The document itself
xetex	4.0	/usr/local/texlive/2022basic/texmf-dist/doc/xetex/base/XeTeX-notes.pdf		About XeTeX
xetex	4.0	/usr/local/texlive/2022basic/texmf-dist/doc/xetex/font-change-xetex/font-change-xetex.pdf	Package documentation
xetex	4.0	/usr/local/texlive/2022basic/texmf-dist/doc/xetex/xesearch/xesearch.pdf		Package documentation
```

In case there will be more packages having `xetex` in their names and alphabetically lower than `xetex-reference`, this PR (re)enables alias for `xetex` to give `xetex-reference` extra scores.