### PR TITLE
Fix #89, add --print-completion zsh

### DIFF
--- a/doc/texdoc.1.md
+++ b/doc/texdoc.1.md
@@ -51,6 +51,8 @@ Alternatively, perform the given ACTION and exit.
   Print the list of configuration files used.
 * `--just-view` FILE:
   Display FILE, given with full path (no searching).
+* `--print-completion` SHELL:
+  Print SHELL completion.
 
 ## ENVIRONMENT
 

--- a/doc/texdoc.tex
+++ b/doc/texdoc.tex
@@ -151,6 +151,35 @@ but rather intended to be used from another program, like a GUI front-end to
 Texdoc.
 \end{clopt}
 
+\begin{clopt}{\code{\lopt{print-completion}=\meta{SHELL}}}
+Print |«SHELL»| completion. Now it only supports zsh. (A pull request is welcome!)
+
+Zsh users must \verb|autoload -Uz compinit && compinit| in \verb|~/.zshrc| to enable completion. Then users have two methods to install completion scripts:
+
+\begin{itemize}
+  \item Users can add \verb|eval "$(texdoc completion zsh)"| to \verb|~/.zshrc|.
+  \item Users can add the following file (also provided by \href{https://github.com/zsh-users/zsh-completions}{zsh-completions}) to \\\verb|/usr/share/zsh/site-functions/_texdoc|:
+\begin{verbatim}
+#compdef texdoc
+(( $+functions[__texdoc] )) || eval "$(texdoc complete zsh)" &&
+  __texdoc
+\end{verbatim}
+    Then \verb|grep texdoc ~/.zcompdump| to confirm:
+\begin{verbatim}
+'texdoc' '_texdoc'
+\end{verbatim}
+If not, \verb|rm ~/.zcompdump|, then \verb|compinit| again.
+\end{itemize}
+\end{clopt}
+
+Note: \verb|/usr/share| is only for GNU/Linux, for other OSs, try:
+\begin{description}
+  \item[macOS (homebrew, x86)]\verb|/usr/local/share|
+  \item[macOS (homebrew, arm)]\verb|/opt/homebrew/share|
+  \item[Android (Termux)]\verb|/data/data/com.termux/files/usr/share|
+  \item[Windows (Msys2 Mingw64)]\verb|/mingw64/share|
+\end{description}
+
 Some normal options such as \sopt{v} are effective for some actions but note
 that you have to specify such options \emph{before} the action option. Options
 after an action option will be ignored.

--- a/script/texdoclib-cli.tlu
+++ b/script/texdoclib-cli.tlu
@@ -81,14 +81,17 @@ end
 
 local function parse_options()
     local curr_arg
+    local option
     local cl_config = {}
 
-    local function insert_cl_config(key, val, opt_name)
-        table.insert(cl_config, {key, val, opt_name})
-    end
-
     -- actual parsing
-    opts = getopt(arg, 'cd')
+    local optstring = ''
+    for _, o in pairs(C.options) do
+        if o['type'] == 'string' and o['short'] then
+            optstring = optstring .. o['short']
+        end
+    end
+    local opts = getopt(arg, optstring)
 
     for _, tp in ipairs(opts) do
         local k, v = tp[1], tp[2]
@@ -98,52 +101,28 @@ local function parse_options()
             curr_arg = '--' .. k
         end
 
-        -- action
-        if (curr_arg == '-h') or (curr_arg == '--help') then
-            return true, 'help', cl_config
-        elseif (curr_arg == '-V') or (curr_arg == '--version') then
-            return true, 'version', cl_config
-        elseif (curr_arg == '-f') or (curr_arg == '--files') then
-            return true, 'files', cl_config
-        elseif curr_arg == '--just-view' then
-            return true, 'view', cl_config
+        for i, o in ipairs(C.options) do
+            if k == o["short"] or k == o["long"] then
+                k = i
+                break
+            end
+        end
 
-        -- mode
-        elseif (curr_arg == '-w') or (curr_arg == '--view') then
-            insert_cl_config('mode', 'view', curr_arg)
-        elseif (curr_arg == '-m') or (curr_arg == '--mixed') then
-            insert_cl_config('mode', 'mixed', curr_arg)
-        elseif (curr_arg == '-l') or (curr_arg == '--list') then
-            insert_cl_config('mode', 'list', curr_arg)
-        elseif (curr_arg == '-s') or (curr_arg == '--showall') then
-            insert_cl_config('mode', 'showall', curr_arg)
-
-        -- interaction
-        elseif (curr_arg == '-I') or (curr_arg == '--nointeract') then
-            insert_cl_config('interact_switch', 'false', curr_arg)
-        elseif (curr_arg == '-i') or (curr_arg == '--interact') then
-            insert_cl_config('interact_switch', 'true', curr_arg)
-
-        -- output format
-        elseif (curr_arg == '-M') or (curr_arg == '--machine') then
-            insert_cl_config('machine_switch', 'true', curr_arg)
-
-        -- config
-        elseif curr_arg == '-c' then
-            insert_cl_config(v, nil, curr_arg)
-
-        -- debug
-        elseif (curr_arg == '-d') or (curr_arg == '--debug') then
-            if v == true then v = 'all' end
-            insert_cl_config('debug_list', v, curr_arg)
-        elseif curr_arg == '-D' then
-            insert_cl_config('debug_list', 'all', curr_arg)
-
-        -- verbosity
-        elseif (curr_arg == '-q') or (curr_arg == '--quiet') then
-            insert_cl_config('verbosity_level', C.min_verbosity, curr_arg)
-        elseif (curr_arg == '-v') or (curr_arg == '--verbose') then
-            insert_cl_config('verbosity_level', C.max_verbosity, curr_arg)
+        option = C.options[k]
+        if option['group'] == 'action' then
+            if option['long'] == 'just-view' then
+                return true, 'view', cl_config
+            elseif option['long'] == 'print-completion' then
+                return true, 'complete', cl_config
+            else
+                return true, option['long'], cl_config
+            end
+        elseif option['group'] then
+            if option['type'] == 'boolean' then
+                option['action'](cl_config, curr_arg)
+            elseif option['type'] == 'string' then
+                option['action'](cl_config, curr_arg, v)
+            end
 
         -- having trouble
         else
@@ -180,6 +159,18 @@ local function do_action(action)
         end
         texdoc.view.view_file(arg[1])
         os.exit(C.exit_ok)
+    elseif action == 'complete' then
+        if not arg[1] then
+            err_print('error', 'Missing shell operand to --print-completion.')
+            err_print('error', C.error_msg)
+            os.exit(C.exit_usage)
+        elseif arg[1] == 'zsh' then
+            texdoc.util.print_zsh_completion()
+            os.exit(C.exit_ok)
+        else
+            err_print('error', arg[1] .. ' is not supported currently!')
+            os.exit(C.exit_error)
+        end
     end
 end
 

--- a/script/texdoclib-const.tlu
+++ b/script/texdoclib-const.tlu
@@ -35,33 +35,229 @@ Try to find appropriate TeX documentation for the specified NAME(s).
 Alternatively, perform the given ACTION and exit.
 
 Options:
-  -w, --view        Use view mode: start a viewer. (default)
-  -m, --mixed       Use mixed mode (view or list).
-  -l, --list        Use list mode: show a list of results.
-  -s, --showall     Use showall mode: show also "bad" results.
+{{mode}}
 
-  -i, --interact    Use interactive menus. (default)
-  -I, --nointeract  Use plain lists, no interaction required.
-  -M, --machine     Machine-readable output for lists (implies -I).
+{{interaction}}
 
-  -q, --quiet       Suppress warnings and most error messages.
-  -v, --verbose     Print additional information (e.g., viewer command).
-  -D, --debug       Activate all debug output (equal to "--debug=all").
-  -d LIST, --debug=LIST
-                    Activate debug output restricted to LIST.
-  -c NAME=VALUE     Set configuration item NAME to VALUE.
+{{debug}}
 
 Actions:
-  -h, --help        Print this help message.
-  -V, --version     Print the version number.
-  -f, --files       Print the list of configuration files used.
-  --just-view FILE  Display FILE, given with full path (no searching).
+{{action}}
 
 Full manual available via `texdoc texdoc'.
 
 Website: <https://tug.org/texdoc/>
 Repository: <https://github.com/TeX-Live/texdoc>
 Please email bugs to <texdoc@tug.org>.]]
+
+zsh_completion = [[
+compdef __texdoc texdoc
+
+__texdoc() {
+  local options=(
+    {{action}}
+    + mode
+    {{mode}}
+    + interaction
+    {{interaction}}
+    + debug
+    {{debug}}
+  )
+  _arguments -C -A $options \
+    '*: :->arguments' && return
+  case $state in
+    arguments)
+      local tlpdb="$(kpsewhich -var-value TEXMFROOT)/tlpkg/texlive.tlpdb"
+      _values package $(awk '/^name[^.]*$/ {print $2}' $tlpdb)
+    ;;
+  esac
+}
+]]
+
+--[[ structure of the options table
+
+options = {
+    {
+        desc = 'description',
+        long = 'long name',
+        short = 'short name',
+        type = 'argument type'
+        group = 'same group will only complete once, that is `texdoc --interact <TAB>` will not complete `--nointeract`'
+        action = function to be called
+    },
+    ...
+}
+--]]
+
+options = {
+    -- action
+    {
+        desc = 'Print this help message.',
+        long = 'help',
+        short = 'h',
+        type = 'boolean',
+        group = 'action'
+    },
+    {
+        desc = 'Print the version number.',
+        long = 'version',
+        short = 'V',
+        type = 'boolean',
+        group = 'action'
+    },
+    {
+        desc = 'Print the list of configuration files used.',
+        long = 'files',
+        short = 'f',
+        type = 'boolean',
+        group = 'action'
+    },
+    {
+        desc = 'Display FILE, given with full path (no searching).',
+        long = 'just-view',
+        type = 'string',
+        metavar = 'FILE',
+        complete = 'files',
+        group = 'action'
+    },
+    {
+        desc = 'Print SHELL completion.',
+        long = 'print-completion',
+        type = 'string',
+        metavar = 'SHELL',
+        complete = {'zsh'},
+        group = 'action',
+    },
+    -- mode
+    {
+        desc = 'Use view mode: start a viewer. (default)',
+        long = 'view',
+        short = 'w',
+        type = 'boolean',
+        group = 'mode',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'mode', 'view', opt_name})
+        end
+    },
+    {
+        desc = 'Use mixed mode (view or list).',
+        long = 'mixed',
+        short = 'm',
+        type = 'boolean',
+        group = 'mode',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'mode', 'mixed', opt_name})
+        end
+    },
+    {
+        desc = 'Use list mode: show a list of results.',
+        long = 'list',
+        short = 'l',
+        type = 'boolean',
+        group = 'mode',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'mode', 'list', opt_name})
+        end
+    },
+    {
+        desc = 'Use showall mode: show also "bad" results.',
+        long = 'showall',
+        short = 's',
+        type = 'boolean',
+        group = 'mode',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'mode', 'showall', opt_name})
+        end
+    },
+    -- interaction
+    {
+        desc = 'Use interactive menus. (default)',
+        long = 'interact',
+        short = 'i',
+        type = 'boolean',
+        group = 'interaction',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'interact_switch', 'true', opt_name})
+        end
+    },
+    {
+        desc = 'Use plain lists, no interaction required.',
+        long = 'nointeract',
+        short = 'I',
+        type = 'boolean',
+        group = 'interaction',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'interact_switch', 'false', opt_name})
+        end
+    },
+    -- output format
+    {
+        desc = 'Machine-readable output for lists (implies -I).',
+        long = 'machine',
+        short = 'M',
+        type = 'boolean',
+        group = 'interaction',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'machine_switch', 'true', opt_name})
+        end
+    },
+    -- verbosity
+    {
+        desc = 'Suppress warnings and most error messages.',
+        long = 'quiet',
+        short = 'q',
+        type = 'boolean',
+        group = 'debug',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'verbosity_level', '0', opt_name})
+        end
+    },
+    {
+        desc = 'Print additional information (e.g., viewer command).',
+        long = 'verbose',
+        short = 'v',
+        type = 'boolean',
+        group = 'debug',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'verbosity_level', '3', opt_name})
+        end
+    },
+    -- debug
+    {
+        desc = 'Activate all debug output (equal to "--debug=all").',
+        short = 'D',
+        type = 'boolean',
+        group = 'debug',
+        action = function(cl_config, opt_name)
+            table.insert(cl_config, {'debug_list', 'all', opt_name})
+        end
+    },
+    {
+        desc = 'Activate debug output restricted to LIST.',
+        long = 'debug',
+        short = 'd',
+        metavar = 'LIST',
+        type = 'string',
+        complete = 'debugs',
+        group = 'debug',
+        action = function(cl_config, opt_name, val)
+            if val == true then val = 'all' end
+            table.insert(cl_config, {'debug_list', val, opt_name})
+        end
+    },
+    -- config
+    {
+        desc = 'Set configuration item NAME to VALUE.',
+        short = 'c',
+        metavar = 'NAME=VALUE',
+        type = 'string',
+        complete = 'options',
+        group = 'debug',
+        action = function(cl_config, opt_name, val)
+            table.insert(cl_config, {val, nil, opt_name})
+        end
+    },
+}
 
 copyright_msg = [[
 Copyright 2008-2022 Manuel Pégourié-Gonnard, Takuto Asakura, the TeX Live Team.

--- a/script/texdoclib-util.tlu
+++ b/script/texdoclib-util.tlu
@@ -143,7 +143,119 @@ end
 
 -- print a usage message
 function M.print_usage()
-    print(C.usage_msg)
+    local groups = {
+        action = {},
+        mode = {},
+        interaction = {},
+        debug = {},
+    }
+    for _, opt in ipairs(C.options) do
+        local line = ''
+        local shortopt = ''
+        local longopt = ''
+        if opt['short'] then
+            if opt['short'] == 'D' then
+                opt['long'] = 'debug'
+            end
+            if opt['metavar'] then
+                shortopt = '-' .. opt['short'] .. ' ' .. opt['metavar']
+            else
+                shortopt = '-' .. opt['short']
+            end
+        end
+        if opt['long'] then
+            if opt['metavar'] then
+                local sep = '='
+                if opt['group'] == 'action' then
+                    sep = ' '
+                end
+                longopt = '--' .. opt['long'] .. sep .. opt['metavar']
+            else
+                longopt = '--' .. opt['long']
+            end
+        end
+        if #shortopt > 0 and #longopt > 0 then
+            line = '  ' .. shortopt .. ', ' .. longopt
+        elseif #shortopt > 0 then
+            line = '  ' .. shortopt
+        elseif #longopt > 0 then
+            line = '  ' .. longopt
+        end
+        if #line > 20 then
+            line = line .. "\n"
+        end
+        for _ = 1, 20 - #string.gsub(line, ".*\n", '') do
+            line = line .. ' '
+        end
+        line = line .. opt['desc']
+        table.insert(groups[opt['group']], line)
+    end
+    local usage_msg = C.usage_msg
+    for k, v in pairs(groups) do
+        usage_msg = string.gsub(usage_msg, '{{' .. k .. '}}', table.concat(v, "\n"))
+    end
+    print(usage_msg)
+end
+
+function M.print_zsh_completion()
+    local groups = {
+        action = {},
+        mode = {},
+        interaction = {},
+        debug = {},
+    }
+    local option = ''
+    local complete = ''
+    local choices = {}
+    local prefix = ''
+    for _, opt in ipairs(C.options) do
+        local stop_completions = {opt['group']}
+        if opt['group'] == 'action' then
+            stop_completions = {'-', ':', '*'}
+        end
+        prefix = '"(' .. table.concat(stop_completions, ' ') .. ')"'
+        if opt['short'] and opt['long'] then
+            if opt['long'] == 'debug' then
+                option = '{-' .. opt['short'] .. ',--' .. opt['long'] .. '=-}'
+            else
+                option = '{-' .. opt['short'] .. ',--' .. opt['long'] .. '}'
+            end
+        elseif opt['short'] then
+            option = '-' .. opt['short']
+        elseif opt['long'] then
+            option = '--' .. opt['long']
+        end
+        option = prefix .. option .. '"[' .. opt['desc'] .. ']'
+        if opt['type'] == 'string' then
+            if opt['complete'] == 'options' then
+                choices = {}
+                for _, v in pairs(C.known_options) do
+                    v = string.gsub(v, '%.%*', '')
+                    table.insert(choices, v)
+                end
+            elseif opt['complete'] == 'debugs' then
+                choices = {}
+                for i, _ in pairs(C.known_debugs) do
+                    table.insert(choices, i)
+                end
+            elseif type(opt['complete']) == 'table' then
+                choices = opt['complete']
+            end
+            complete = '(' .. table.concat(choices, ' ') .. ')'
+            if opt['complete'] == 'files' then
+                opt['metavar'] = ' '
+                complete = '_files'
+            end
+            option = option .. ':' .. string.lower(opt['metavar']) .. ':' .. complete
+        end
+        option = option .. '"'
+        table.insert(groups[opt['group']], option)
+    end
+    local completion = C.zsh_completion
+    for k, v in pairs(groups) do
+        completion = string.gsub(completion, '{{' .. k .. '}}', table.concat(v, "\n    "))
+    end
+    print(completion)
 end
 
 return M

--- a/spec/action/help_spec.rb
+++ b/spec/action/help_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe 'The "help" action', :type => :aruba do
         -V, --version     Print the version number.
         -f, --files       Print the list of configuration files used.
         --just-view FILE  Display FILE, given with full path (no searching).
+        --print-completion SHELL
+                          Print SHELL completion.
 
       Full manual available via `texdoc texdoc'.
 

--- a/spec/action/print_completion_spec.rb
+++ b/spec/action/print_completion_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe 'The "print-completion" action', :type => :aruba do
+  include_context "messages"
+
+  context "with --print-completion zsh" do
+    before(:each) { run_texdoc "--print-completion zsh" }
+
+    it do
+      expect(stdout).to include("compdef __texdoc texdoc")
+      expect(last_command_started).to be_successfully_executed
+    end
+  end
+end


### PR DESCRIPTION
For convenience to realize, now every option has a short name and a long
name:
  -c, --config
  -W, --just-view
  -S, --print-completion
Update man page and pdf
Add install completion method in pdf
Use `texdoc.config.options` to generate help text and shell completion
script
Add stop_completion in `texdoc.config.options`, such as `--view` will
stop `--list`, `--showall`, `--mixed`, ... due to all of them change mode
`texdoc --just-view` will complete files while `texdoc --other-option` will complete package names
`texdoc [OPTION]... ACTION` will stop all other options and arguments.

> I don't have the time and motivation to implement and maintain this feature. I will only review codes

There are many changes so reviewing the code maybe also cost a long time, which
I am very sorry to occupy your time.

> You can include that part also

Included. See `texdoc.config.options`.
