### PR TITLE
Add alias kpsewhich = kpathsea

### DIFF
--- a/texdoc.cnf
+++ b/texdoc.cnf
@@ -465,6 +465,7 @@ alias(0.1) fontinst = fontinstallationguide
 alias hyperref-dev = hyperref.pdf
 alias iso = isoman
 alias knuth-pdf = knuth-pdf/index.pdf
+alias kpsewhich = kpathsea
 alias kvoptions-patch = kvoptions  # XXX?
 alias layouts = layman
 alias lettrine = lettrine          # to hide context/third/lettrine-doc.pdf


### PR DESCRIPTION
Currently `texdoc kpsewhich` returns no results although `kpsewhich` is documented in kpathsea.pdf (and the equivalent kpathsea.html).
I have checked that kpathsea.pdf does not document the other `kpse*` commands (which are less relevant besides), so only this alias is necessary.
