### PR TITLE
List more kinds of possible packages/documents/aliases in zsh completion

### DIFF
--- a/script/texdoclib-const.tlu
+++ b/script/texdoclib-const.tlu
@@ -63,14 +63,26 @@ __texdoc() {
     + debug
     {{debug}}
   )
-  _arguments -C -A $options \
-    '*: :->arguments' && return
-  case $state in
-    arguments)
-      local tlpdb="$(kpsewhich -var-value TEXMFROOT)/tlpkg/texlive.tlpdb"
-      _values package $(awk '/^name[^.]*$/ {print $2}' $tlpdb)
-    ;;
-  esac
+  _arguments -C -A $options '*:document:__texdoc_argument'
+}
+
+__texdoc_argument() {
+  _alternative \
+    "files:local documents:$(__texdoc_massage __texdoc_localfiles)" \
+    "aliases:aliases:$(__texdoc_massage __texdoc_aliases)" \
+    "packages:packages:$(__texdoc_massage __texdoc_packages)" \
+    "pdf:documents:$(__texdoc_massage __texdoc_lsr pdf)" \
+}
+
+# stdout of $@ is split at linebreaks, ordered, element-wise quoted, space joined, and ripped of empty words
+__texdoc_massage() { echo \(${(j: :)${(@q)${(ou)${(f)"$($@ 2>/dev/null)"}}}:#"''"}\) }
+
+__texdoc_localfiles() { find -L "$(kpsewhich -var-value TEXMFHOME)/doc" -type f -printf '%f\n' }
+__texdoc_aliases() { sed -n 's/^alias[^ ]* \(.*\) = .*$/\1/p' "${(f@)"$(texdoc --files|sed -n 's/^\s\+active\s\+//p')"}" }
+__texdoc_lsr() { grep -h "\\.$1$" "${(f@)"$(kpsewhich -all ls-R)"}" }
+__texdoc_packages() { # Use texlive.tlpdb if it exists, otherwise fallback to texdoc's own data
+  sed -n '/\./!s/^name //p' "${(f@)"$(kpsewhich -all -cnf-line='TEXINPUTS={$TEXMFROOT,$TEXMFHOME}/tlpkg' -format=tex texlive.tlpdb)"}" \
+  || sed -n 's/^  \["\([^"]*\)"\] = {$/\1/p' "$(kpsewhich Data.tlpdb.lua)"
 }
 
 if [[ $zsh_eval_context[-1] == loadautofunc ]]; then


### PR DESCRIPTION
Thanks a lot for providing a zsh completion ❤️ I love shell completions and so I improved it (at least from my point of view) a little further by enlarging the list of package and document names, the completion script suggests.

The current completion uses the package names from `$TEXMFROOT/texlive.tlpdb`, this is usually nice, but with TeX-Live installed as Debian package, this `texlive.tlpdb` does not even exist 😕 Hence, I added five more sources of which at least some should exist and provide helpful completions:

* Package names listed in a local `$TEXMFHOME/texlive.tlpdb`.
* If `texlive.tlpdb` exists neither locally, nor system wide: fallback to texdoc’s own `Data.tlpdb.lua`.
* PDF files listed in the `ls-R` file.
* Aliases registered in `texdoc-dist.cnf` and `texdoc.cnf`.
* Any files found in `$TEXMFHOME/doc`.

I hope you like it and feel free to criticize 😀