### PR TITLE
Fix parsing `texdoc -c --help` etc. (#121)

### DIFF
--- a/script/texdoclib-cli.tlu
+++ b/script/texdoclib-cli.tlu
@@ -58,14 +58,10 @@ local function getopt(arg, options)
                     end
 
                     -- check the existence of an argument
-                    if not tmp then
+                    if not tmp or tmp:match('^%-') then
                         err_print('error',
                             'Option -%s requires an argument.', jopt)
                         os.exit(C.exit_error)
-                    end
-
-                    if tmp:match('^%-') then
-                        table.insert(tab, {jopt, false})
                     else
                         table.insert(tab, {jopt, tmp})
                     end


### PR DESCRIPTION
It’s just what the title says. All options put in the second argument of `getopt` must have a string as argument. For the other options any placeholder works (here it is `true` which semantically makes sense). The branch that set the argument to `false` must have always led to the error described in #121 since `false` is no string.