### PR TITLE
Make zsh completion reproducible

### DIFF
--- a/script/texdoclib-util.tlu
+++ b/script/texdoclib-util.tlu
@@ -241,6 +241,7 @@ function M.print_zsh_completion()
             elseif type(opt['complete']) == 'table' then
                 choices = opt['complete']
             end
+            table.sort(choices)
             complete = '(' .. table.concat(choices, ' ') .. ')'
             if opt['complete'] == 'files' then
                 opt['metavar'] = ' '


### PR DESCRIPTION
Currently, the possible values for `--debug` appear in a non-deterministic order, resulting in `texdoc --print-completion zsh` output changing on each invocation. Sorting mitigates this, yielding reproducible results.